### PR TITLE
Add comprehensive pytest suite for infogroove

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev]"
+
+      - name: Run test suite
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ uv run infogroove -f examples/arc-circles/arc-circles.igd -i examples/arc-circle
 uv run infogroove -f examples/staggered-keywords/staggered-keywords.igd -i examples/staggered-keywords/staggered-keywords.json -o examples/staggered-keywords/staggered-keywords.svg
 ```
 
+## Running Tests
+
+Install development dependencies and execute the test suite with pytest:
+
+```bash
+uv sync --extra dev
+uv run --extra dev pytest
+```
+
+To measure coverage locally you can add the ``--cov`` flag:
+
+```bash
+uv run --extra dev pytest --cov=infogroove --cov=tests
+```
+
 ## Example Gallery
 
 | Template | Preview |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
     "sympy>=1.14.0",
 ]
 
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
 [project.scripts]
 infogroove = "infogroove.cli:main"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,117 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from infogroove import render_svg
+from infogroove.cli import _load_data, _write_output, main
+from infogroove.exceptions import DataValidationError
+
+
+def test_load_data_supports_array_and_wrapped(tmp_path):
+    array_path = tmp_path / "data.json"
+    array_path.write_text(json.dumps([{"value": 1}]), encoding="utf-8")
+    wrapped_path = tmp_path / "wrapped.json"
+    wrapped_path.write_text(json.dumps({"items": [{"value": 2}]}), encoding="utf-8")
+
+    assert _load_data(str(array_path)) == [{"value": 1}]
+    assert _load_data(str(wrapped_path)) == [{"value": 2}]
+
+    invalid_path = tmp_path / "invalid.json"
+    invalid_path.write_text(json.dumps({"items": [1]}), encoding="utf-8")
+
+    with pytest.raises(DataValidationError):
+        _load_data(str(invalid_path))
+
+    with pytest.raises(DataValidationError):
+        _load_data(str(tmp_path / "missing.json"))
+
+
+def test_write_output_handles_stdout(tmp_path, capsys):
+    output_path = tmp_path / "output.svg"
+    _write_output("<svg />", str(output_path))
+    assert output_path.read_text(encoding="utf-8") == "<svg />"
+
+    _write_output("<svg />", "-")
+    captured = capsys.readouterr()
+    assert "<svg />" in captured.out
+
+
+def test_main_renders_svg_end_to_end(tmp_path):
+    template_path = tmp_path / "template.igd"
+    template_path.write_text(
+        json.dumps(
+            {
+                "screen": {"width": 100, "height": 100},
+                "elements": [
+                    {
+                        "type": "text",
+                        "attributes": {"x": 0, "y": 0},
+                        "text": "{item.label}",
+                    }
+                ],
+                "formulas": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    data_path = tmp_path / "data.json"
+    data_path.write_text(json.dumps([{"label": "Hello"}]), encoding="utf-8")
+    output_path = tmp_path / "out.svg"
+
+    exit_code = main(["-f", str(template_path), "-i", str(data_path), "-o", str(output_path)])
+
+    assert exit_code == 0
+    rendered = output_path.read_text(encoding="utf-8")
+    assert "Hello" in rendered
+    assert "svg" in rendered
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{}",
+        "[1, 2, 3]",
+        "not json",
+    ],
+)
+def test_render_svg_helper(tmp_path, payload):
+    template_path = tmp_path / "template.igd"
+    template_path.write_text(
+        json.dumps(
+            {
+                "screen": {"width": 100, "height": 100},
+                "elements": [
+                    {
+                        "type": "rect",
+                        "attributes": {"width": "{screen.width}", "height": "10"},
+                        "scope": "canvas",
+                    }
+                ],
+                "formulas": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    if payload == "not json":
+        data_path = tmp_path / "broken.json"
+        data_path.write_text(payload, encoding="utf-8")
+        with pytest.raises(DataValidationError):
+            _load_data(str(data_path))
+        return
+
+    data_path = tmp_path / "data.json"
+    data_path.write_text(payload, encoding="utf-8")
+    data = json.loads(payload)
+
+    if isinstance(data, list):
+        if all(isinstance(item, dict) for item in data):
+            markup = render_svg(str(template_path), data)
+            assert "svg" in markup
+        else:
+            with pytest.raises(DataValidationError):
+                render_svg(str(template_path), data)
+    else:
+        with pytest.raises(DataValidationError):
+            _load_data(str(data_path))

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+import pytest
+import sympy
+
+from infogroove.exceptions import FormulaEvaluationError
+from infogroove.formula import FormulaEngine
+
+
+def test_formula_engine_evaluates_with_sympy_numbers():
+    engine = FormulaEngine({"double": "value * 2", "offset": "double + 1"})
+
+    results = engine.evaluate({"value": 3})
+
+    assert results == {"double": 6, "offset": 7}
+
+
+def test_formula_engine_falls_back_to_python_eval(monkeypatch):
+    engine = FormulaEngine({"total": "sum(items)"})
+
+    def boom(*args, **kwargs):  # pragma: no cover - patched in test
+        raise sympy.SympifyError("fail")
+
+    monkeypatch.setattr(sympy, "sympify", boom)
+    items = [1, 2, 3]
+    results = engine.evaluate({"items": items})
+
+    assert results["total"] == sum(items)
+
+
+def test_formula_engine_raises_on_failure(monkeypatch):
+    engine = FormulaEngine({"bad": "items['missing']"})
+
+    def boom(*args, **kwargs):
+        raise sympy.SympifyError("fail")
+
+    monkeypatch.setattr(sympy, "sympify", boom)
+
+    with pytest.raises(FormulaEvaluationError):
+        engine.evaluate({"items": [{}]})

--- a/tests/test_package_init.py
+++ b/tests/test_package_init.py
@@ -1,0 +1,22 @@
+from infogroove import InfographicRenderer, get_version, load_template, render_svg
+
+
+def test_get_version_returns_fallback(monkeypatch):
+    class Boom(Exception):
+        pass
+
+    def fail(name):  # pragma: no cover - executed when patched
+        raise Boom
+
+    from importlib import metadata
+
+    monkeypatch.setattr(metadata, "version", fail)
+    monkeypatch.setattr(metadata, "PackageNotFoundError", Boom)
+
+    assert get_version() == "0.0.0"
+
+
+def test_public_api_exports():
+    assert isinstance(InfographicRenderer, type)
+    assert callable(load_template)
+    assert callable(render_svg)

--- a/tests/test_template_loader.py
+++ b/tests/test_template_loader.py
@@ -1,0 +1,98 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from infogroove.exceptions import TemplateError
+from infogroove.template_loader import _parse_template, load_template
+
+
+def make_template_payload(**overrides):
+    payload = {
+        "screen": {"width": 800, "height": 600},
+        "elements": [
+            {
+                "type": "rect",
+                "attributes": {"width": 10, "height": 20},
+                "scope": "canvas",
+            },
+            {
+                "type": "text",
+                "attributes": {"x": 0, "y": 0},
+                "text": "hello",
+            },
+        ],
+        "formulas": {"double": "value * 2"},
+        "styles": {"color": "#fff"},
+        "numElementsRange": [1, 3],
+        "schema": {"type": "array"},
+        "name": "Example",
+        "description": "Demo",
+        "version": "1.0",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_load_template_reads_and_parses(tmp_path):
+    template_path = tmp_path / "template.igd"
+    template_path.write_text(json.dumps(make_template_payload()), encoding="utf-8")
+
+    template = load_template(template_path)
+
+    assert template.source_path == template_path
+    assert template.screen.width == 800
+    assert template.elements[0].scope == "canvas"
+    assert template.elements[1].text == "hello"
+    assert template.formulas["double"] == "value * 2"
+    assert template.styles["color"] == "#fff"
+    assert template.num_elements_range == (1, 3)
+    assert template.schema == {"type": "array"}
+    assert template.metadata == {
+        "name": "Example",
+        "description": "Demo",
+        "version": "1.0",
+    }
+
+
+def test_parse_template_accepts_screen_fallbacks(tmp_path):
+    payload = make_template_payload(screen={}, screenWidth=400, screenHeight=500)
+    template = _parse_template(tmp_path / "template.igd", payload)
+
+    assert template.screen.width == 400
+    assert template.screen.height == 500
+
+
+@pytest.mark.parametrize(
+    "overrides, message",
+    [
+        ({"screen": "oops"}, "'screen' must be a mapping"),
+        ({"screen": {}}, "Both screen width"),
+        ({"elements": {}}, "'elements' must"),
+        (
+            {"elements": [{"type": 1}]},
+            "Element definitions require",
+        ),
+        (
+            {"elements": [{"type": "rect", "attributes": []}]},
+            "Element attributes must",
+        ),
+        (
+            {"elements": [{"type": "rect", "attributes": {}, "text": 1}]},
+            "Element text must",
+        ),
+        (
+            {"elements": [{"type": "rect", "attributes": {}, "scope": "row"}]},
+            "Element scope must",
+        ),
+        ({"formulas": []}, "'formulas' must"),
+        ({"styles": []}, "'styles' must"),
+    ],
+)
+def test_parse_template_validation_errors(tmp_path, overrides, message):
+    payload = make_template_payload(**overrides)
+
+    with pytest.raises(TemplateError) as exc:
+        _parse_template(tmp_path / "template.igd", payload)
+
+    assert message in str(exc.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,86 @@
+import math
+
+import pytest
+
+from infogroove.utils import (
+    MappingAdapter,
+    PLACEHOLDER_PATTERN,
+    SequenceAdapter,
+    default_eval_locals,
+    ensure_accessible,
+    fill_placeholders,
+    find_dotted_tokens,
+    prepare_expression_for_sympy,
+    replace_tokens,
+    resolve_path,
+    tokenize_path,
+    to_camel_case,
+    to_snake_case,
+)
+
+
+def test_sequence_and_mapping_adapters_expose_helpers():
+    adapter = ensure_accessible({"items": [1, {"value": 3}]})
+    assert isinstance(adapter, MappingAdapter)
+
+    items = adapter["items"]
+    assert isinstance(items, SequenceAdapter)
+    values = list(items)
+    assert values[0] == 1
+    assert values[1]["value"] == 3
+    assert items.length == 2
+
+    with pytest.raises(AttributeError):
+        _ = adapter.missing
+
+
+def test_tokenize_and_resolve_path_supports_indices():
+    context = {
+        "items": [
+            {"value": 3, "meta": {"label": "A"}},
+            {"value": 5, "meta": {"label": "B"}},
+        ]
+    }
+    assert tokenize_path("items[1].meta.label") == ["items", "1", "meta", "label"]
+    assert resolve_path(context, "items[1].meta.label") == "B"
+    assert resolve_path(context, "items.length") == 2
+
+
+def test_case_conversion_helpers():
+    assert to_snake_case("CamelCase") == "camel_case"
+    assert to_camel_case("some_value") == "someValue"
+
+
+def test_find_and_replace_tokens_preserves_order():
+    expression = "styles.primary.color + styles.secondary.color"
+    tokens = find_dotted_tokens(expression)
+    assert tokens == ["styles.primary.color", "styles.secondary.color"]
+
+    replaced = replace_tokens(expression, {token: "x" for token in tokens})
+    assert replaced == "x + x"
+
+
+def test_prepare_expression_for_sympy_and_eval_namespace():
+    context = {"metrics": {"maxValue": 3}, "value": 10}
+    sanitized, locals_ = prepare_expression_for_sympy("metrics.maxValue + value", context)
+
+    assert sanitized != "metrics.maxValue + value"  # dotted access replaced with placeholders
+    placeholder = next(key for key in locals_ if key.startswith("__v"))
+    assert locals_[placeholder] == 3
+    assert locals_["value"] == 10
+
+    safe_locals = default_eval_locals(context)
+    assert safe_locals["abs"] is abs
+    assert math is safe_locals["math"]
+    assert safe_locals["metrics"]["maxValue"] == 3
+
+
+def test_fill_placeholders_inserts_context_values():
+    context = {"item": {"value": 5, "label": "Five"}}
+    template = "Value={item.value} Label={item.label}"
+    assert PLACEHOLDER_PATTERN.search(template)
+    rendered = fill_placeholders(template, context)
+    assert rendered == "Value=5 Label=Five"
+
+    with pytest.raises(KeyError):
+        fill_placeholders("{missing.value}", context)

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,15 @@
 version = 1
-revision = 1
+revision = 2
 requires-python = ">=3.12"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
 
 [[package]]
 name = "infogroove"
@@ -11,28 +20,87 @@ dependencies = [
     { name = "sympy" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "svg-py", specifier = ">=1.9.1" },
     { name = "sympy", specifier = ">=1.14.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106 }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198 },
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
 name = "svg-py"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/99/ec05caaac1f5b9b5172dc379ab2824ed6f289153fc26cbc46900eba8b18d/svg_py-1.9.1.tar.gz", hash = "sha256:8702c5b952d58edccff0df9aa28e29bdc521cd8b1c175aaceeb1a3d10817b77c", size = 43717 }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/99/ec05caaac1f5b9b5172dc379ab2824ed6f289153fc26cbc46900eba8b18d/svg_py-1.9.1.tar.gz", hash = "sha256:8702c5b952d58edccff0df9aa28e29bdc521cd8b1c175aaceeb1a3d10817b77c", size = 43717, upload-time = "2025-10-03T06:49:29.535Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/59/221806e7be32efba4a1d4f8c37053bd242884aeef1f33307947554c88712/svg_py-1.9.1-py3-none-any.whl", hash = "sha256:58ae244680bd92c1e26aacaaca73b086b0f4b2ac67ee3d7770f2d7878ca344f4", size = 15152 },
+    { url = "https://files.pythonhosted.org/packages/2b/59/221806e7be32efba4a1d4f8c37053bd242884aeef1f33307947554c88712/svg_py-1.9.1-py3-none-any.whl", hash = "sha256:58ae244680bd92c1e26aacaaca73b086b0f4b2ac67ee3d7770f2d7878ca344f4", size = 15152, upload-time = "2025-10-03T06:49:27.492Z" },
 ]
 
 [[package]]
@@ -42,7 +110,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mpmath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921 }
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353 },
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]


### PR DESCRIPTION
## Summary
- add extensive pytest coverage for template loading, rendering, formulas, CLI, and utility helpers
- document how to install the dev extra and run the automated test suite
- declare pytest as an optional dev dependency in the project metadata

## Testing
- uv run --extra dev pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1e0f086d483308925156ab12c160a