### PR TITLE
Cache compiled expressions and bump version

### DIFF
--- a/infogroove/formula.py
+++ b/infogroove/formula.py
@@ -2,15 +2,120 @@
 
 from __future__ import annotations
 
+import ast
+import re
 from collections import ChainMap
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any
 
 import sympy
 from sympy.core.sympify import SympifyError
 
 from .exceptions import FormulaEvaluationError
-from .utils import _unwrap_accessible, prepare_expression_for_sympy, safe_ast_eval
+from .utils import (
+    UnsafeExpressionError,
+    _unwrap_accessible,
+    find_dotted_tokens,
+    find_identifier_tokens,
+    resolve_path,
+    safe_ast_eval,
+)
+
+_EXPRESSION_CACHE_SIZE = 1024
+
+
+@dataclass(frozen=True)
+class _SympyPlan:
+    dotted_tokens: tuple[str, ...]
+    identifier_tokens: tuple[str, ...]
+    token_pattern: re.Pattern[str] | None
+
+
+@dataclass(frozen=True)
+class _AstPlan:
+    tree: ast.Expression | None
+    syntax_error: SyntaxError | None
+    identifier_tokens: tuple[str, ...]
+
+
+def _compile_token_pattern(tokens: tuple[str, ...]) -> re.Pattern[str] | None:
+    if not tokens:
+        return None
+    escaped = "|".join(re.escape(token) for token in sorted(tokens, key=len, reverse=True))
+    return re.compile(escaped)
+
+
+@lru_cache(maxsize=_EXPRESSION_CACHE_SIZE)
+def _identifier_tokens(expression: str) -> tuple[str, ...]:
+    return tuple(find_identifier_tokens(expression))
+
+
+@lru_cache(maxsize=_EXPRESSION_CACHE_SIZE)
+def _dotted_tokens(expression: str) -> tuple[str, ...]:
+    return tuple(find_dotted_tokens(expression))
+
+
+@lru_cache(maxsize=_EXPRESSION_CACHE_SIZE)
+def _compile_sympy_plan(expression: str) -> _SympyPlan:
+    dotted = _dotted_tokens(expression)
+    identifiers = _identifier_tokens(expression)
+    pattern = _compile_token_pattern(dotted)
+    return _SympyPlan(dotted_tokens=dotted, identifier_tokens=identifiers, token_pattern=pattern)
+
+
+@lru_cache(maxsize=_EXPRESSION_CACHE_SIZE)
+def _compile_ast_plan(expression: str) -> _AstPlan:
+    identifiers = _identifier_tokens(expression)
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        return _AstPlan(tree=None, syntax_error=exc, identifier_tokens=identifiers)
+    return _AstPlan(tree=tree, syntax_error=None, identifier_tokens=identifiers)
+
+
+def _prepare_sympy_expression(
+    expression: str,
+    context: Mapping[str, Any],
+    plan: _SympyPlan,
+) -> tuple[str, dict[str, Any]]:
+    replacements: dict[str, str] = {}
+    sympy_locals: dict[str, Any] = {}
+    for token in plan.dotted_tokens:
+        root = token.split(".", 1)[0]
+        if root not in context:
+            continue
+        try:
+            value = resolve_path(context, token)
+        except KeyError:
+            continue
+        placeholder = f"__v{len(replacements)}"
+        replacements[token] = placeholder
+        sympy_locals[placeholder] = value
+    if plan.token_pattern is None:
+        sanitized = expression
+    else:
+        sanitized = plan.token_pattern.sub(
+            lambda match: replacements.get(match.group(0), match.group(0)),
+            expression,
+        )
+    for name in plan.identifier_tokens:
+        if not name.isidentifier():
+            continue
+        try:
+            value = context[name]
+        except KeyError:
+            continue
+        sympy_locals.setdefault(name, value)
+    return sanitized, sympy_locals
+
+
+def _clear_expression_caches() -> None:
+    _identifier_tokens.cache_clear()
+    _dotted_tokens.cache_clear()
+    _compile_sympy_plan.cache_clear()
+    _compile_ast_plan.cache_clear()
 
 
 class FormulaEngine:
@@ -42,7 +147,8 @@ def evaluate_expression(
 ) -> Any:
     """Evaluate a template expression with sympy first, then a safe AST fallback."""
 
-    sanitized, sympy_locals = prepare_expression_for_sympy(expression, context)
+    sympy_plan = _compile_sympy_plan(expression)
+    sanitized, sympy_locals = _prepare_sympy_expression(expression, context, sympy_plan)
     try:
         value = sympy.sympify(sanitized, locals=sympy_locals)
         if isinstance(value, sympy.Basic) and value.free_symbols:
@@ -54,7 +160,15 @@ def evaluate_expression(
         pass
 
     try:
-        raw_result = safe_ast_eval(expression, context)
+        ast_plan = _compile_ast_plan(expression)
+        if ast_plan.syntax_error is not None:
+            raise UnsafeExpressionError("Invalid expression syntax") from ast_plan.syntax_error
+        raw_result = safe_ast_eval(
+            expression,
+            context,
+            compiled=ast_plan.tree,
+            identifiers=ast_plan.identifier_tokens,
+        )
         return _normalise_value(raw_result)
     except Exception as ast_exc:
         message = f"Failed to evaluate expression '{expression}'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "infogroove"
-version = "0.4.2"
+version = "0.5.0"
 description = "Programmable infographic generation powered by sympy and svg.py"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -4,7 +4,8 @@ import pytest
 import sympy
 
 from infogroove.exceptions import FormulaEvaluationError
-from infogroove.formula import FormulaEngine
+from infogroove import formula as formula_module
+from infogroove.formula import FormulaEngine, evaluate_expression
 
 
 def test_formula_engine_evaluates_with_sympy_numbers():
@@ -38,3 +39,46 @@ def test_formula_engine_raises_on_failure(monkeypatch):
 
     with pytest.raises(FormulaEvaluationError):
         engine.evaluate({"items": [{}]})
+
+
+def test_expression_cache_reuses_sympy_tokens(monkeypatch):
+    formula_module._clear_expression_caches()
+    calls = {"dotted": 0}
+
+    original = formula_module.find_dotted_tokens
+
+    def wrapped(expression: str):
+        calls["dotted"] += 1
+        return original(expression)
+
+    monkeypatch.setattr(formula_module, "find_dotted_tokens", wrapped)
+
+    assert evaluate_expression("value * 2", {"value": 2}) == 4
+    assert evaluate_expression("value * 2", {"value": 3}) == 6
+
+    assert calls["dotted"] == 1
+
+
+def test_expression_cache_reuses_ast_parse(monkeypatch):
+    formula_module._clear_expression_caches()
+    calls = {"parse": 0}
+
+    original = formula_module.ast.parse
+
+    def wrapped(*args, **kwargs):
+        calls["parse"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(formula_module.ast, "parse", wrapped)
+
+    def boom(*args, **kwargs):  # pragma: no cover - patched in test
+        raise sympy.SympifyError("fail")
+
+    monkeypatch.setattr(sympy, "sympify", boom)
+
+    assert evaluate_expression("value + 1", {"value": 1}) == 2
+    first_count = calls["parse"]
+
+    assert evaluate_expression("value + 1", {"value": 2}) == 3
+
+    assert calls["parse"] == first_count

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "infogroove"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary
- cache compiled expression tokens and AST parsing to avoid repeated work during renders
- extend safe AST evaluation helpers to accept precompiled artifacts
- add tests that assert caching behavior
- bump project version to 0.5.0 and refresh uv.lock

## Testing
- uv run pytest

Closes #18