### PR TITLE
Deduplicate adapter unwrapping helper

### DIFF
--- a/infogroove/formula.py
+++ b/infogroove/formula.py
@@ -16,11 +16,11 @@ from sympy.core.sympify import SympifyError
 from .exceptions import FormulaEvaluationError
 from .utils import (
     UnsafeExpressionError,
-    _unwrap_accessible,
     find_dotted_tokens,
     find_identifier_tokens,
     resolve_path,
     safe_ast_eval,
+    unwrap_accessible,
 )
 
 _EXPRESSION_CACHE_SIZE = 1024
@@ -186,7 +186,7 @@ def _coerce_integral(value: Any) -> Any:
 
 
 def _normalise_value(value: Any) -> Any:
-    value = _unwrap_accessible(value)
+    value = unwrap_accessible(value)
     if isinstance(value, Mapping):
         return {key: _normalise_value(sub) for key, sub in value.items()}
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):

--- a/infogroove/utils.py
+++ b/infogroove/utils.py
@@ -74,14 +74,17 @@ def ensure_accessible(value: Any) -> Any:
     return value
 
 
-def _unwrap_accessible(value: Any) -> Any:
+def unwrap_accessible(value: Any) -> Any:
     """Convert Mapping/Sequence adapters back to built-in container types."""
 
     if isinstance(value, MappingAdapter):
-        return {key: _unwrap_accessible(value[key]) for key in value}
+        return {key: unwrap_accessible(value[key]) for key in value}
     if isinstance(value, SequenceAdapter):
-        return [_unwrap_accessible(item) for item in value]
+        return [unwrap_accessible(item) for item in value]
     return value
+
+
+_unwrap_accessible = unwrap_accessible
 
 
 def stringify(value: Any) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "infogroove"
-version = "0.5.0"
+version = "0.5.1"
 description = "Programmable infographic generation powered by sympy and svg.py"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -16,6 +16,15 @@ def test_formula_engine_evaluates_with_sympy_numbers():
     assert results == {"double": 6, "offset": 7}
 
 
+def test_evaluate_expression_unwraps_accessible_containers():
+    context = {"items": [{"value": 1}, {"value": 2}]}
+
+    result = evaluate_expression("items", context)
+
+    assert isinstance(result, list)
+    assert result == [{"value": 1}, {"value": 2}]
+
+
 def test_formula_engine_falls_back_to_python_eval(monkeypatch):
     engine = FormulaEngine({"total": "sum(items)"})
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import ast
 import math
 import random
 
@@ -18,6 +19,7 @@ from infogroove.utils import (
     tokenize_path,
     to_camel_case,
     to_snake_case,
+    unwrap_accessible,
 )
 
 
@@ -34,6 +36,16 @@ def test_sequence_and_mapping_adapters_expose_helpers():
 
     with pytest.raises(AttributeError):
         _ = adapter.missing
+
+
+def test_unwrap_accessible_returns_builtin_types():
+    adapter = ensure_accessible({"items": [{"value": 1}, {"value": 2}]})
+
+    unwrapped = unwrap_accessible(adapter)
+
+    assert isinstance(unwrapped, dict)
+    assert isinstance(unwrapped["items"], list)
+    assert unwrapped["items"][0] == {"value": 1}
 
 
 def test_tokenize_and_resolve_path_supports_indices():
@@ -86,6 +98,14 @@ def test_fill_placeholders_inserts_context_values():
 
     with pytest.raises(FormulaEvaluationError):
         fill_placeholders("{missing.value}", context)
+
+
+def test_fill_placeholders_unwraps_adapter_results():
+    context = {"items": [{"value": 1}, {"value": 2}]}
+
+    rendered = fill_placeholders("{items}", context)
+
+    assert ast.literal_eval(rendered) == [{"value": 1}, {"value": 2}]
 
 
 def test_fill_placeholders_evaluates_inline_expressions():

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "infogroove"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary
- centralize adapter unwrapping in utils and reuse it from formula evaluation
- add coverage for unwrapping in helpers and placeholder rendering
- bump version to 0.5.1

## Testing
- uv venv -p python3.11 .venv && source .venv/bin/activate && uv sync --extra dev --active && pytest

Closes #20