### PR TITLE
Add create-infogroove skill assets and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Omit `-o` to print the SVG to stdout:
 uvx infogroove -f /path/to/def.json -i /path/to/data.json > output.svg
 ```
 
+## Codex Skill
+
+Install the Infogroove Codex skill:
+
+```bash
+$skill-installer install https://github.com/comfuture/infogroove/tree/main/skills/create-infogroove
+```
+
 ## Running Tests
 
 Install development dependencies and execute the test suite with pytest:

--- a/skills/create-infogroove/SKILL.md
+++ b/skills/create-infogroove/SKILL.md
@@ -64,6 +64,14 @@ skills/create-infogroove/scripts/render_infogroove.py \
 - Tighten layout, spacing, and colors as needed.
 - Update `schema` when data shape changes.
 
+## Prerequisites
+
+The rendering script uses `uvx`. If the target system does not have Python or
+uv installed, install them first:
+
+- Python: https://docs.astral.sh/uv/guides/install-python/
+- uv: https://docs.astral.sh/uv/getting-started/installation/
+
 ## Resources
 
 ### scripts/
@@ -73,3 +81,11 @@ skills/create-infogroove/scripts/render_infogroove.py \
 ### references/
 
 - `infogroove-template-guide.md`: Quick reference for the template spec, data shapes, and examples.
+
+### assets/
+
+Example template definitions copied from the repo examples for quick starting points:
+
+- [`blue-parallelograms.json`](assets/blue-parallelograms.json)
+- [`key-messages.json`](assets/key-messages.json)
+- [`stat-cards.json`](assets/stat-cards.json)

--- a/skills/create-infogroove/assets/blue-parallelograms.json
+++ b/skills/create-infogroove/assets/blue-parallelograms.json
@@ -1,0 +1,159 @@
+{
+  "name": "Blue Parallelogram Bands",
+  "description": "Displays adjacent skewed bands with tonal blue fills.",
+  "properties": {
+    "canvas": {
+      "width": 1200,
+      "height": 420
+    },
+    "margin_top": 48,
+    "margin_bottom": 48,
+    "margin_left": 40,
+    "margin_right": 40,
+    "skew": 28,
+    "font_family": "Inter, Arial, sans-serif",
+    "title_color": "#0f172a",
+    "value_color": "#1e3a8a",
+    "colors": [
+      "#1d4ed8",
+      "#2563eb",
+      "#3b82f6",
+      "#60a5fa",
+      "#93c5fd"
+    ],
+    "background": "#f8fafc"
+  },
+  "schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Parallelogram band payload",
+    "description": "Top-level payload that contains the bands collection and optional secondary series.",
+    "required": [
+      "items"
+    ],
+    "properties": {
+      "items": {
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 8,
+        "items": {
+          "type": "object",
+          "required": [
+            "title",
+            "value"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Headline label shown at the top of the band."
+            },
+            "value": {
+              "type": ["number", "string"],
+              "description": "Secondary figure rendered beneath the title."
+            },
+            "values": {
+              "type": "array",
+              "description": "Optional series values for downstream consumers.",
+              "items": {
+                "type": "number"
+              }
+            },
+            "points": {
+              "type": "array",
+              "description": "Optional precomputed polygon points when overriding geometry.",
+              "items": {
+                "type": "object",
+                "required": ["x", "y"],
+                "additionalProperties": false,
+                "properties": {
+                  "x": {"type": "number"},
+                  "y": {"type": "number"}
+                }
+              }
+            }
+          }
+        }
+      },
+      "items2": {
+        "type": "array",
+        "description": "Optional secondary collection that agents may use for comparisons.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "title": {"type": "string"},
+            "value": {"type": ["number", "string"]}
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  },
+  "template": [
+    {
+      "type": "rect",
+      "attributes": {
+        "x": "0",
+        "y": "0",
+        "width": "100%",
+        "height": "100%",
+        "fill": "{background}"
+      }
+    },
+    {
+      "type": "g",
+      "repeat": {
+        "items": "items",
+        "as": "entry"
+      },
+      "let": {
+        "title": "entry.title",
+        "value": "entry.value",
+        "bar_width": "(canvas.width - margin_left - margin_right - skew) / max(__total__, 1)",
+        "x": "margin_left + __index__ * bar_width",
+        "top_y": "margin_top",
+        "bottom_y": "canvas.height - margin_bottom",
+        "color_index": "__index__ % colors.length",
+        "fill_color": "colors[color_index]",
+        "points": "{x},{top_y} {x + bar_width},{top_y} {x + bar_width + skew},{bottom_y} {x + skew},{bottom_y}",
+        "label_x": "x + (bar_width + skew) / 2",
+        "label_y": "top_y + 44",
+        "value_y": "label_y + 30"
+      },
+      "children": [
+        {
+          "type": "polygon",
+          "attributes": {
+            "points": "{points}",
+            "fill": "{fill_color}"
+          }
+        },
+        {
+          "type": "text",
+          "attributes": {
+            "x": "{label_x}",
+            "y": "{label_y}",
+            "fill": "{title_color}",
+            "fontFamily": "{font_family}",
+            "fontSize": "24",
+            "fontWeight": "600",
+            "textAnchor": "middle"
+          },
+          "text": "{title}"
+        },
+        {
+          "type": "text",
+          "attributes": {
+            "x": "{label_x}",
+            "y": "{value_y}",
+            "fill": "{value_color}",
+            "fontFamily": "{font_family}",
+            "fontSize": "18",
+            "textAnchor": "middle"
+          },
+          "text": "{value}"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/create-infogroove/assets/key-messages.json
+++ b/skills/create-infogroove/assets/key-messages.json
@@ -1,0 +1,282 @@
+{
+  "name": "Key Messages",
+  "description": "Highlights a primary message above supporting messages.",
+  "properties": {
+    "canvas": {
+      "width": 1024,
+      "height": 576
+    },
+    "margin": 48,
+    "gap": 32,
+    "background": "#120613",
+    "card_radius": 28,
+    "font_family": "'Inter', 'Pretendard', Arial, sans-serif",
+    "lead_gradient_start": "#ff2d95",
+    "lead_gradient_end": "#b5147a",
+    "card_gradient_start": "#ff9ad1",
+    "card_gradient_end": "#ff68b3",
+    "lead_text_color": "#fff5fc",
+    "secondary_text_color": "#250014",
+    "lead_title_size": 48,
+    "lead_subtitle_size": 26,
+    "card_title_size": 24,
+    "card_subtitle_size": 18
+  },
+  "schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Key message payload",
+    "description": "Top-level payload containing a featured message followed by supporting cards.",
+    "required": [
+      "items"
+    ],
+    "properties": {
+      "items": {
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 6,
+        "items": {
+          "type": "object",
+          "required": [
+            "title",
+            "subtitle"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Hero or supporting message headline."
+            },
+            "subtitle": {
+              "type": "string",
+              "description": "Secondary copy displayed beneath the title."
+            }
+          }
+        }
+      },
+      "items2": {
+        "type": "array",
+        "description": "Optional secondary messages used by downstream agents.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "title": {"type": "string"},
+            "subtitle": {"type": "string"}
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "template": [
+    {
+      "type": "rect",
+      "attributes": {
+        "x": "0",
+        "y": "0",
+        "width": "100%",
+        "height": "100%",
+        "fill": "{background}"
+      }
+    },
+    {
+      "type": "defs",
+      "children": [
+        {
+          "type": "linearGradient",
+          "attributes": {
+            "id": "leadGradient",
+            "x1": "0%",
+            "y1": "0%",
+            "x2": "0%",
+            "y2": "100%"
+          },
+          "children": [
+            {
+              "type": "stop",
+              "attributes": {
+                "offset": "0%",
+                "stopColor": "{lead_gradient_start}"
+              }
+            },
+            {
+              "type": "stop",
+              "attributes": {
+                "offset": "100%",
+                "stopColor": "{lead_gradient_end}"
+              }
+            }
+          ]
+        },
+        {
+          "type": "linearGradient",
+          "attributes": {
+            "id": "cardGradient",
+            "x1": "0%",
+            "y1": "0%",
+            "x2": "0%",
+            "y2": "100%"
+          },
+          "children": [
+            {
+              "type": "stop",
+              "attributes": {
+                "offset": "0%",
+                "stopColor": "{card_gradient_start}"
+              }
+            },
+            {
+              "type": "stop",
+              "attributes": {
+                "offset": "100%",
+                "stopColor": "{card_gradient_end}"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "g",
+      "repeat": {
+        "items": "items",
+        "as": "entry"
+      },
+      "let": {
+        "title": "entry.title",
+        "subtitle": "entry.subtitle",
+        "half_height": "canvas.height / 2",
+        "section_gap": "gap",
+        "lead_width": "canvas.width - margin * 2",
+        "lead_x": "margin",
+        "lead_y": "margin",
+        "lead_height": "half_height - margin - section_gap / 2",
+        "lead_display": "'inline' if __first__ else 'none'",
+        "non_lead_display": "'inline' if not __first__ else 'none'",
+        "bottom_y": "half_height + section_gap / 2",
+        "bottom_height": "canvas.height - bottom_y - margin",
+        "non_lead_count": "max(__total__ - 1, 1)",
+        "non_lead_index": "max(__index__ - 1, 0)",
+        "card_width": "((canvas.width - margin * 2) - gap * (non_lead_count - 1)) / non_lead_count if __index__ > 0 else 0",
+        "card_height": "bottom_height",
+        "card_x": "margin + non_lead_index * (card_width + gap)",
+        "card_y": "bottom_y",
+        "lead_title_x": "lead_x + 40",
+        "lead_title_y": "lead_y + 110",
+        "lead_subtitle_y": "lead_y + 148",
+        "card_title_x": "card_x + 28",
+        "card_title_y": "card_y + 82",
+        "card_subtitle_y": "card_y + 132",
+        "subtitle_clip_id": "keyMsgClip_{__index__}",
+        "subtitle_clip_x": "lead_title_x if __first__ else card_title_x",
+        "subtitle_clip_y": "lead_subtitle_y - 4 if __first__ else card_subtitle_y - 4",
+        "subtitle_clip_width": "(lead_width - 88) if __first__ else max(card_width - 56, 0)",
+        "subtitle_clip_height": "(lead_height - 120) if __first__ else max(card_height - 140, 0)"
+      },
+      "children": [
+        {
+          "type": "defs",
+          "children": [
+            {
+              "type": "clipPath",
+              "attributes": {
+                "id": "{subtitle_clip_id}"
+              },
+              "children": [
+                {
+                  "type": "rect",
+                  "attributes": {
+                    "x": "{subtitle_clip_x}",
+                    "y": "{subtitle_clip_y}",
+                    "width": "{subtitle_clip_width}",
+                    "height": "{subtitle_clip_height}"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "rect",
+          "attributes": {
+            "x": "{lead_x}",
+            "y": "{lead_y}",
+            "width": "{lead_width}",
+            "height": "{lead_height}",
+            "rx": "{card_radius}",
+            "fill": "url(#leadGradient)",
+            "display": "{lead_display}"
+          }
+        },
+        {
+          "type": "text",
+          "attributes": {
+            "x": "{lead_title_x}",
+            "y": "{lead_title_y}",
+            "fill": "{lead_text_color}",
+            "fontSize": "{lead_title_size}",
+            "fontFamily": "{font_family}",
+            "fontWeight": "700",
+            "display": "{lead_display}",
+            "dominantBaseline": "middle"
+          },
+          "text": "{title}"
+        },
+        {
+          "type": "text",
+          "attributes": {
+            "x": "{lead_title_x}",
+            "y": "{lead_subtitle_y}",
+            "fill": "{lead_text_color}",
+            "fontSize": "{lead_subtitle_size}",
+            "fontFamily": "{font_family}",
+            "dominantBaseline": "hanging",
+            "display": "{lead_display}",
+            "clip-path": "url(#{subtitle_clip_id})"
+          },
+          "text": "{subtitle}"
+        },
+        {
+          "type": "rect",
+          "attributes": {
+            "x": "{card_x}",
+            "y": "{card_y}",
+            "width": "{card_width}",
+            "height": "{card_height}",
+            "rx": "{card_radius}",
+            "fill": "url(#cardGradient)",
+            "display": "{non_lead_display}"
+          }
+        },
+        {
+          "type": "text",
+          "attributes": {
+            "x": "{card_title_x}",
+            "y": "{card_title_y}",
+            "fill": "{secondary_text_color}",
+            "fontSize": "{card_title_size}",
+            "fontFamily": "{font_family}",
+            "fontWeight": "600",
+            "display": "{non_lead_display}",
+            "dominantBaseline": "middle"
+          },
+          "text": "{title}"
+        },
+        {
+          "type": "text",
+          "attributes": {
+            "x": "{card_title_x}",
+            "y": "{card_subtitle_y}",
+            "fill": "{secondary_text_color}",
+            "fontSize": "{card_subtitle_size}",
+            "fontFamily": "{font_family}",
+            "dominantBaseline": "hanging",
+            "display": "{non_lead_display}",
+            "clip-path": "url(#{subtitle_clip_id})"
+          },
+          "text": "{subtitle}"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/create-infogroove/assets/stat-cards.json
+++ b/skills/create-infogroove/assets/stat-cards.json
@@ -1,0 +1,175 @@
+{
+  "name": "Stat Cards",
+  "description": "Displays KPI cards with coloured accents.",
+  "properties": {
+    "canvas": {
+      "width": 1024,
+      "height": 600
+    },
+    "margin": 48,
+    "card_width": 280,
+    "card_height": 140,
+    "card_gap": 24,
+    "background": "#0f172a",
+    "card_background": "#1e293b",
+    "title_color": "#e2e8f0",
+    "value_color": "#f8fafc",
+    "delta_color": "#94a3b8",
+    "font_family": "Inter, Arial, sans-serif",
+    "accent_colors": [
+      "#38bdf8",
+      "#34d399",
+      "#f97316",
+      "#a855f7"
+    ]
+  },
+  "schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Stat card payload",
+    "description": "Top-level payload containing card entries and optional comparative data.",
+    "required": [
+      "items"
+    ],
+    "properties": {
+      "items": {
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 8,
+        "items": {
+          "type": "object",
+          "required": [
+            "title",
+            "value",
+            "delta"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Short KPI name displayed at the top of the card."
+            },
+            "value": {
+              "type": ["number", "string"],
+              "description": "Primary metric shown prominently in the card."
+            },
+            "delta": {
+              "type": "string",
+              "description": "Context or change indicator rendered beneath the value."
+            }
+          }
+        }
+      },
+      "items2": {
+        "type": "array",
+        "description": "Optional comparative series for downstream analysis.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "title": {"type": "string"},
+            "value": {"type": ["number", "string"]},
+            "delta": {"type": "string"}
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "template": [
+    {
+      "type": "rect",
+      "attributes": {
+        "x": "0",
+        "y": "0",
+        "width": "100%",
+        "height": "100%",
+        "fill": "{background}"
+      }
+    },
+    {
+      "type": "g",
+      "repeat": {
+        "items": "items",
+        "as": "entry"
+      },
+      "let": {
+        "title": "entry.title",
+        "value": "entry.value",
+        "delta": "entry.delta",
+        "cards_per_row": "max(1, min(__total__, 3))",
+        "row": "__index__ // cards_per_row",
+        "column": "__index__ % cards_per_row",
+        "card_x": "margin + column * (card_width + card_gap)",
+        "card_y": "margin + row * (card_height + card_gap)",
+        "accent_color": "accent_colors[__index__ % accent_colors.length]",
+        "title_x": "card_x + 20",
+        "title_y": "card_y + 36",
+        "value_x": "card_x + 20",
+        "value_y": "card_y + 82",
+        "delta_x": "card_x + 20",
+        "delta_y": "card_y + 112"
+      },
+      "children": [
+        {
+          "type": "rect",
+          "attributes": {
+            "x": "{card_x}",
+            "y": "{card_y}",
+            "width": "{card_width}",
+            "height": "{card_height}",
+            "fill": "{card_background}",
+            "rx": "20"
+          }
+        },
+        {
+          "type": "rect",
+          "attributes": {
+            "x": "{card_x}",
+            "y": "{card_y}",
+            "width": "6",
+            "height": "{card_height}",
+            "fill": "{accent_color}",
+            "rx": "6"
+          }
+        },
+        {
+          "type": "text",
+          "attributes": {
+            "x": "{title_x}",
+            "y": "{title_y}",
+            "fill": "{title_color}",
+            "fontSize": "18",
+            "fontFamily": "{font_family}",
+            "dominantBaseline": "middle"
+          },
+          "text": "{title}"
+        },
+        {
+          "type": "text",
+          "attributes": {
+            "x": "{value_x}",
+            "y": "{value_y}",
+            "fill": "{value_color}",
+            "fontSize": "40",
+            "fontFamily": "{font_family}",
+            "fontWeight": "700",
+            "dominantBaseline": "middle"
+          },
+          "text": "{value}"
+        },
+        {
+          "type": "text",
+          "attributes": {
+            "x": "{delta_x}",
+            "y": "{delta_y}",
+            "fill": "{delta_color}",
+            "fontSize": "16",
+            "fontFamily": "{font_family}",
+            "dominantBaseline": "middle"
+          },
+          "text": "{delta}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add example template assets for the create-infogroove skill
- document asset links and prerequisites in SKILL.md
- document the Codex skill install command in README

## Testing
- not run (not requested)